### PR TITLE
Fix INotificationHandler registering when using AddScope

### DIFF
--- a/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,7 +36,15 @@ namespace Mediator.Switch.Extensions.Microsoft.DependencyInjection
 
             foreach (var handlerType in notificationHandlerTypes)
             {
+                // Register the concrete type
                 services.AddScoped(handlerType);
+                
+                // Also register against notification handler interfaces
+                foreach (var handlerInterface in handlerType.GetInterfaces()
+                    .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(INotificationHandler<>)))
+                {
+                    services.AddScoped(handlerInterface, handlerType);
+                }
             }
 
             // Register Pipeline Behaviors


### PR DESCRIPTION
Closes #8

`AddScope` does not register `INotificationHandler<T>` for each concrete type (i.e.. `UserLoggedInLogger`, `UserLoggedInAnalytics`).  Use of `OrderNotificationHandlers` adds `IEnumerable<INotificationHandler<T>>` with specified order.



`AddScoped` would register:
```
INotificationHandler`1[[UserLoggedInEvent, ... ImplementationType = "UserLoggedInLogger"
INotificationHandler`1[[UserLoggedInEvent, ... ImplementationType = "UserLoggedInAnalytics"
```

`OrderNotificationHandlers` would register:
```
INotificationHandler`1[[UserLoggedInEvent, ... ImplementationFactory = IEnumerable`1[INotificationHandler`1[UserLoggedInEvent]]
```

Using the combination as below registers all of the above.
```
services.AddScoped<SwitchMediator>(typeof(Program).Assembly)
    .OrderNotificationHandlers<UserLoggedInEvent>(
        typeof(UserLoggedInLogger),
        typeof(UserLoggedInAnalytics)
    );
```


In this PR, when using assembly scanning through `AddScoped`, or `OrderNotificationHandlers`, or both... we resolve the necessary `IEnumerable<INotificationHandler<T>>`. If `OrderNotificationHandlers` is not utilized, the service container will provide all `INotificationHandler<T>` as `IEnumerable`