### PR TITLE
Implements options to allow mediator configuration.

### DIFF
--- a/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/SwitchMediatorOptions.cs
+++ b/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/SwitchMediatorOptions.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediator.Switch.Extensions.Microsoft.DependencyInjection;
+
+public class SwitchMediatorOptions
+{
+	/// <summary>
+	/// The assemblies scanned for handlers and behaviors.
+	/// </summary>
+	public Assembly[] TargetAssemblies { get; set; } = [];
+	
+	/// <summary>
+	/// The default lifetime for the services registered by the mediator.
+	/// </summary>
+	public ServiceLifetime ServiceLifetime { get; set; } = ServiceLifetime.Scoped;
+}

--- a/src/Sample.ConsoleApp/Program.cs
+++ b/src/Sample.ConsoleApp/Program.cs
@@ -11,7 +11,11 @@ public static class Program
     {
         var services = new ServiceCollection();
         services.AddValidatorsFromAssembly(typeof(Program).Assembly);
-        services.AddScoped<SwitchMediator>(typeof(Program).Assembly)
+        services.AddMediator<SwitchMediator>(op =>
+            {
+                op.TargetAssemblies = [typeof(Program).Assembly];
+                op.ServiceLifetime = ServiceLifetime.Singleton;
+            })
             .OrderNotificationHandlers<UserLoggedInEvent>(
                 typeof(UserLoggedInLogger),
                 typeof(UserLoggedInAnalytics)


### PR DESCRIPTION
Adds configuration options for the mediator service.  `AddScoped<T>` replaced with `AddMediator<T>`.
The motivation for this PR is that not every use case may need scoped services when a singleton might suffice.

This PR will need additional changes when/if #10 is merged.