### PR TITLE
Resolve IEnumerable<INotificationHandler<T>> from IServiceProvider

### DIFF
--- a/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
+++ b/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
@@ -22,7 +22,7 @@ public static class CodeGenerator
         });
         
         var notificationHandlerFields = notifications.Select(n =>
-            $"private IEnumerable<INotificationHandler<{n}>> _{n.GetVariableName()}__Handlers;");
+            $"private readonly IEnumerable<INotificationHandler<{n}>> _{n.GetVariableName()}__Handlers;");
 
         // Generate constructor parameters
         var constructorParams = handlers.Select(h => $"{h.Class} {h.Class.GetVariableName()}");

--- a/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
+++ b/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
@@ -25,7 +25,8 @@ public static class CodeGenerator
             $"private readonly IEnumerable<INotificationHandler<{n}>> _{n.GetVariableName()}__Handlers;");
 
         // Generate constructor parameters
-        var constructorParams = handlers.Select(h => $"{h.Class} {h.Class.GetVariableName()}");
+        var constructorParams = handlers.Select(h => $"{h.Class} {h.Class.GetVariableName()}")
+            .Prepend("IServiceProvider serviceProvider");
         var behaviorParams = requestBehaviors.SelectMany(r =>
         {
             var (request, applicableBehaviors) = r;
@@ -119,7 +120,7 @@ public static class CodeGenerator
                   private readonly IServiceProvider _serviceProvider;
                   {{string.Join("\n    ", handlerFields.Concat(behaviorFields).Concat(notificationHandlerFields))}}
               
-                  public SwitchMediator(IServiceProvider serviceProvider,
+                  public SwitchMediator(
                       {{string.Join(",\n        ", constructorParams)}})
                   {
                       _serviceProvider = serviceProvider;


### PR DESCRIPTION
Closes #15.

Rather than injecting `IEnumerable<INotificationHandler<T>>` into SwitchMediator, it is resolved from the service provider.