### PR TITLE
Resolves cases where ordering isn't defined.

### DIFF
--- a/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Mediator.Switch.Extensions.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -71,10 +71,9 @@ public static class ServiceCollectionExtensions
     {
         foreach (var n in notificationTypes)
         {
-            if (!options.OrderedNotificationHandlers.TryGetValue(n.NotificationType, out var orderedHandlerTypes))
-                continue;
+            if (options.OrderedNotificationHandlers.TryGetValue(n.NotificationType, out var orderedHandlerTypes))
+                Sort(n.HandlerTypes, orderedHandlerTypes);
             
-            Sort(n.HandlerTypes, orderedHandlerTypes);
             foreach (var handlerType in n.HandlerTypes)
             {
                 services.TryAdd(new ServiceDescriptor(


### PR DESCRIPTION
When not explicitly providing ordering, `UserLoggedInEvent`s are not properly published. This can be verified in the current sample.

This PR resolves cases where ordering is not provided, but all NotificationHandler<T> are still registered.