### PR TITLE
Feature: Invoke

### DIFF
--- a/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
+++ b/src/Mediator.Switch.SourceGenerator/Generator/CodeGenerator.cs
@@ -136,6 +136,16 @@ public static class CodeGenerator
                        throw new ArgumentException($"No handler for {notification.GetType().Name}");
                    }
                
+                   public Task Invoke(INotification notification, CancellationToken cancellationToken = default)
+                   {
+                       if (PublishSwitchCase.Cases.TryGetValue(notification.GetType(), out var handle))
+                       {
+                           return handle(this, notification, cancellationToken);
+                       }
+                       
+                       return Task.CompletedTask;
+                   }
+               
                    private static class PublishSwitchCase
                    {
                        public static readonly Dictionary<Type, Func<SwitchMediator, INotification, CancellationToken, Task>> Cases = new Dictionary<Type, Func<SwitchMediator, INotification, CancellationToken, Task>>

--- a/src/Mediator.Switch/Abstractions.cs
+++ b/src/Mediator.Switch/Abstractions.cs
@@ -15,12 +15,21 @@ public interface ISender
 public interface IPublisher
 {
     /// <summary>
+    /// Publishes a notification to at least one or multiple handlers.
+    /// </summary>
+    /// <param name="notification">The notification object.</param>
+    /// <param name="cancellationToken">An optional cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>An <see cref="ArgumentException"/> is thrown if there are no handlers.</remarks>
+    Task Publish(INotification notification, CancellationToken cancellationToken = default);
+    
+    /// <summary>
     /// Publishes a notification to multiple handlers.
     /// </summary>
     /// <param name="notification">The notification object.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task Publish(INotification notification, CancellationToken cancellationToken = default);
+    Task Invoke(INotification notification, CancellationToken cancellationToken = default);
 }
 
 public interface IMediator : ISender, IPublisher;

--- a/src/Sample.ConsoleApp/Definitions.cs
+++ b/src/Sample.ConsoleApp/Definitions.cs
@@ -68,6 +68,11 @@ public class User : IVersionedResponse
     public int Version { get; set; }
 }
 
+public record UserLoggedOutEvent(int UserId) : INotification
+{
+    public int UserId { get; } = UserId;
+}
+
 // Request Handlers
 public class GetUserRequestHandler : IRequestHandler<GetUserRequest, Result<User>>
 {

--- a/src/Sample.ConsoleApp/Program.cs
+++ b/src/Sample.ConsoleApp/Program.cs
@@ -60,6 +60,11 @@ public static class Program
         var loginEvent = new DerivedUserLoggedInEvent(123);
         await publisher.Publish(loginEvent);
         Console.WriteLine("--- Notification Published ---\n");
+        
+        Console.WriteLine("--- Invoking UserLoggedOutEvent ---");
+        var logoutEvent = new UserLoggedOutEvent(123);
+        await publisher.Invoke(logoutEvent);
+        Console.WriteLine("--- Notification Invoked ---\n");
 
         Console.WriteLine("--- Sending GetUserRequest with Validation Failure ---");
         try


### PR DESCRIPTION
There may be cases where a particular notification may not have subscribers and an exception should not be thrown. (At least I have a use-case for it).

This PR implements a method `Invoke`, similar to `Publish` but without throwing an exception.